### PR TITLE
Decompress XML when downloading

### DIFF
--- a/download.sh
+++ b/download.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-curl ftp://ftp.monash.edu.au/pub/nihongo/JMdict_e.gz > JMdict_e.xml
+curl ftp://ftp.monash.edu.au/pub/nihongo/JMdict_e.gz | gunzip > JMdict_e.xml


### PR DESCRIPTION
The download script in master `curl`s a .gz file, but writes it directly into the .xml file, so the subsequent build doesn't actually work. This is a one-line change to pipe the download into `gunzip` before writing to the xml file.