### PR TITLE
fix: typo land -> lang

### DIFF
--- a/src/main/kotlin/org/edrdg/jmdict/simplified/conversion/jmdict/JMdictExamplesConverter.kt
+++ b/src/main/kotlin/org/edrdg/jmdict/simplified/conversion/jmdict/JMdictExamplesConverter.kt
@@ -38,7 +38,7 @@ class JMdictExamplesConverter : JMdictBaseConverter<JMdictJsonElement.WordWithEx
                         text = it.text,
                         sentences = it.sentences.map {
                             JMdictJsonElement.ExampleSentence(
-                                land = it.lang,
+                                lang = it.lang,
                                 text = it.text,
                             )
                         },

--- a/src/main/kotlin/org/edrdg/jmdict/simplified/conversion/jmdict/JMdictJsonElement.kt
+++ b/src/main/kotlin/org/edrdg/jmdict/simplified/conversion/jmdict/JMdictJsonElement.kt
@@ -153,7 +153,7 @@ sealed class JMdictJsonElement : CommonJsonElement() {
 
     @Serializable
     data class ExampleSentence(
-        val land: String,
+        val lang: String,
         val text: String,
     )
 }


### PR DESCRIPTION
The examples for words looks like:
```json
{
"sentences": [
        {
            "land": "jpn",
            "text": "あの〜郵便局はどちらでしょうか。"
        },
        {
            "land": "eng",
            "text": "Uh..., where's the post office?"
        }
    ]
}
```

Assuming this `"land"` key is a typo, this PR changes it to look like:
```json
{
"sentences": [
        {
            "lang": "jpn",
            "text": "あの〜郵便局はどちらでしょうか。"
        },
        {
            "lang": "eng",
            "text": "Uh..., where's the post office?"
        }
    ]
}
```